### PR TITLE
Use newer versions of dependancies and add NuGet security auditing

### DIFF
--- a/build/Build.fsproj
+++ b/build/Build.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Build.fsproj
+++ b/build/Build.fsproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Fake.Core.Environment" Version="5.20.3" />
     <PackageReference Include="Fake.Core.Process" Version="5.20.3" />
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    <PackageReference Update="FSharp.Core" Version="6.0.7" />
   </ItemGroup>
 
 </Project>

--- a/build/Build.fsproj
+++ b/build/Build.fsproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fake.Core.Environment" Version="5.20.3" />
-    <PackageReference Include="Fake.Core.Process" Version="5.20.3" />
+    <PackageReference Include="Fake.Core.Environment" Version="6.0.0" />
+    <PackageReference Include="Fake.Core.Process" Version="6.0.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.7" />
   </ItemGroup>
 

--- a/src/ClosedXML.SimpleSheets.fsproj
+++ b/src/ClosedXML.SimpleSheets.fsproj
@@ -12,6 +12,12 @@
     <PackageReleaseNotes>Improved type-inference through the use of extension methods</PackageReleaseNotes>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+    <NuGetAudit>true</NuGetAudit>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="Excel.fs" />
   </ItemGroup>

--- a/src/ClosedXML.SimpleSheets.fsproj
+++ b/src/ClosedXML.SimpleSheets.fsproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.95.4" />
+    <PackageReference Include="ClosedXML" Version="0.96.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.7" />
   </ItemGroup>
 

--- a/src/ClosedXML.SimpleSheets.fsproj
+++ b/src/ClosedXML.SimpleSheets.fsproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.95.4" />
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    <PackageReference Update="FSharp.Core" Version="6.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/ClosedXML.SimpleSheets.fsproj
+++ b/src/ClosedXML.SimpleSheets.fsproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.96.0" />
+    <PackageReference Include="ClosedXML" Version="0.97.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.7" />
   </ItemGroup>
 

--- a/src/Excel.fs
+++ b/src/Excel.fs
@@ -176,7 +176,7 @@ type FieldMap<'T> =
 
         member self.hyperlink(link: 'T -> Uri) =
             let transformer (row: 'T) (cell: IXLCell) =
-                cell.Hyperlink <- XLHyperlink(link row)
+                cell.SetHyperlink(XLHyperlink(link row))
                 cell
             { self with CellTransformers = List.append self.CellTransformers [transformer] }
 
@@ -184,7 +184,7 @@ type FieldMap<'T> =
             let transformer (row: 'T) (cell: IXLCell) =
                 match link row with
                 | Some uri ->
-                    cell.Hyperlink <- XLHyperlink(uri)
+                    cell.SetHyperlink(XLHyperlink(uri))
                     cell
                 | None ->
                     cell
@@ -193,7 +193,7 @@ type FieldMap<'T> =
 
         member self.hyperlink(link: 'T -> XLHyperlink) =
             let transformer (row: 'T) (cell: IXLCell) =
-                cell.Hyperlink <- link row
+                cell.SetHyperlink(link row)
                 cell
             { self with CellTransformers = List.append self.CellTransformers [transformer] }
 
@@ -201,7 +201,7 @@ type FieldMap<'T> =
             let transformer (row: 'T) (cell: IXLCell) =
                 match link row with
                 | Some hyperlink ->
-                    cell.Hyperlink <- hyperlink
+                    cell.SetHyperlink(hyperlink)
                     cell
                 | None ->
                     cell
@@ -302,14 +302,14 @@ type Excel() =
 
     static member field<'T>(map: 'T -> Uri) = FieldMap<'T>.create(fun row cell ->
         let uri = map row
-        cell.Hyperlink <- XLHyperlink(uri)
+        cell.SetHyperlink(XLHyperlink(uri))
         cell.SetValue(uri.ToString())
     )
 
     static member field<'T>(map: 'T -> Uri option) = FieldMap<'T>.create(fun row cell ->
         match map row with
         | Some uri ->
-            cell.Hyperlink <- XLHyperlink(uri)
+            cell.SetHyperlink(XLHyperlink(uri))
             cell.SetValue(uri.ToString())
         | None ->
             cell

--- a/test/Test.fsproj
+++ b/test/Test.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Test.fsproj
+++ b/test/Test.fsproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microcharts" Version="0.9.5.9" />
     <ProjectReference Include="..\src\ClosedXML.SimpleSheets.fsproj" />
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    <PackageReference Update="FSharp.Core" Version="6.0.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request was initiated because I started using NuGet security auditing in my project that uses Simplesheets.  

SimpleSheets was producing security warnings due to dependencies in ClosedXML. Newer versions of ClosedXML no longer require these insecure dependancies.

This pull request updates the dotnet framework used to .Net 6, which is the oldest long term support version of the framework currently in use.  FSharp.Core is updated to 6.07 to match with the framework.

The FAKE packages are updated to the newest available versions.

ClosedXML version is updated to 0.97, which is the first version that no longer requires the problematic package System.Drawing.Common package.

I still wish to update the dependancy on ClosedXML to the newest available version, but there are breaking changes and I do not as yet understand how to fix it in SimpleSheets. I will continue to investigate and hopefully provide another pull request for those changes soon.